### PR TITLE
Vite+Tailwind CSSでは不要になるpostcssを削除

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,6 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.14.0",
-    "postcss": "^8.4.47",
     "prettier": "^3.6.2",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       eslint:
         specifier: ^9.14.0
         version: 9.14.0(jiti@1.21.6)
-      postcss:
-        specifier: ^8.4.47
-        version: 8.4.47
       prettier:
         specifier: ^3.6.2
         version: 3.6.2


### PR DESCRIPTION
最初はNext.jsプロジェクトだったためpostcssをインストールしていたが、
Vite移行時に不要になった。今まで残ってしまっていたので削除する