### PR TITLE
犬の向きを揃えるオプションのデフォルト値をtrueに変更

### DIFF
--- a/web/src/providers/SettingsProvider.tsx
+++ b/web/src/providers/SettingsProvider.tsx
@@ -28,7 +28,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
   const { value: headingTrained, update: setHeadingTrained } =
     useLocalStorage<boolean>({
       key: 'headingTrained',
-      defaultValue: false,
+      defaultValue: true,
       mounted,
     })
 


### PR DESCRIPTION
## Summary
- 「犬の向きを揃える」設定の `defaultValue` を `false` から `true` に変更し、新規ユーザーではデフォルトで ON になるようにしました。
- `useLocalStorage` を使用しているため、既に値が保存されている既存ユーザーには影響しません。

## Test plan
- [ ] localStorage をクリアした状態でアプリを開き、設定がデフォルトで ON になっていることを確認する
- [ ] 既に `headingTrained` を localStorage に持つ場合はその値が維持されることを確認する